### PR TITLE
input type in label

### DIFF
--- a/View/Helper/TwitterBootstrapHelper.php
+++ b/View/Helper/TwitterBootstrapHelper.php
@@ -240,7 +240,7 @@ class TwitterBootstrapHelper extends AppHelper {
 		}
 		return $this->Html->tag(
 			"div",
-			$options['type'].$options['label'].$input,
+			$options['label'].$input,
 			array("class" => $wrap_class)
 		);
 	}


### PR DESCRIPTION
Now it generates code like 

<div class="control-group">password<label for="UserPasswordRepeat" class="control-label">Repeat Password</label><div class="controls"><input name="data[User][password_repeat]" type="password" id="UserPasswordRepeat"></div></div>


After modification:

<div class="control-group"><label for="UserPasswordRepeat" class="control-label">Repeat Password</label><div class="controls"><input name="data[User][password_repeat]" type="password" id="UserPasswordRepeat"></div></div>
