### PR TITLE
some issues about automagic and model name detection

### DIFF
--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -61,6 +61,12 @@ class BootstrapFormHelper extends FormHelper {
 			"prepend" => false,
 			"state" => false
 		);
+		$modelKey = $this->model();
+		$primaryKey = $this->fieldset[$modelKey]['key'];
+		if($field == $primaryKey) {
+			$defaults['type'] = 'hidden';
+		}
+
 		return array_merge($defaults, $options);
 	}
 

--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -216,7 +216,7 @@ class BootstrapFormHelper extends FormHelper {
 		} else {
 			$options["field"] = "{$model}.{$options["field"]}";
 		}*/
-		if ($options['label'] === false) {
+		if ($options['label'] === false || $options['type'] == 'hidden') {
 			$options['label'] = '';
 		} else if (!empty($options['label'])) {
 			$options['label'] = $this->label(

--- a/View/Helper/TwitterBootstrapHelper.php
+++ b/View/Helper/TwitterBootstrapHelper.php
@@ -8,6 +8,14 @@ class TwitterBootstrapHelper extends AppHelper {
 		"TwitterBootstrap.BootstrapForm"
 	);
 
+	public function create_form($model = null, $options = array()) {
+		return $this->BootstrapForm->create($model, $options);
+	}
+
+	public function end_form($options = null) {
+		return $this->BootstrapForm->end($options);
+	}
+
 	public function basic_input($field, $options = array()) {
 		return $this->BootstrapForm->basicInput($field, $options);
 	}

--- a/View/Helper/TwitterBootstrapHelper.php
+++ b/View/Helper/TwitterBootstrapHelper.php
@@ -8,14 +8,6 @@ class TwitterBootstrapHelper extends AppHelper {
 		"TwitterBootstrap.BootstrapForm"
 	);
 
-	public function create_form($model = null, $options = array()) {
-		return $this->BootstrapForm->create($model, $options);
-	}
-
-	public function end_form($options = null) {
-		return $this->BootstrapForm->end($options);
-	}
-
 	public function basic_input($field, $options = array()) {
 		return $this->BootstrapForm->basicInput($field, $options);
 	}


### PR DESCRIPTION
(first of all, sorry if this does not follow your code or naming conventions, it's just a minor fix and kind of an enhancement proposal, not exactly a pull request)

Actually, in a view, <code>$this->TwitterBootstrap</code> is a different object than <code>$this->Form</code> which causes some loses of CakePHP's auto-magic detections.

In concrete, the error that led me to report this is:
Using:

``` php
<?php 
$this->Form->create('Model');
$this->TwitterBootstrap->input('field');
$this->Form->end('Submit');
```

outputs:

``` html
<input name="data[field]" ...
```

Which **you cannot use for Model::save** and forces you to use $this->TwitterBootstrap->input( **'Model.**field')  ergo _no auto-magic for you! :-(_  

A solution I can think of would be to use the _same_ object that creates the form, to create the form elements. It knows the model name: _automagic is back, yay!_ :) 

Then, using:

``` php
<?php 
$this->TwitterBootstrap->create_form('Model');
$this->TwitterBootstrap->input('title');
$this->TwitterBootstrap->end_form('Submit');
```

will output:

``` html
<input name="data[Model][title]" ...
```

This is done by calling <code>BootstrapFormHelper::create</code>, which is directly inherited from FormHelper with no overrides.

**Cons**
- Using <code>$this->TwitterBoostrap->create_form</code> will cause, again, the original problem when trying to use <code>$this->Form->input</code>, in a case where you dont want to use the TwitterBootstrapHepler. 

The other two commits are just a fix to get the automagic done when using <code>$this->TwitterBootstrap->input('id');</code>

Hope it helps, regards
