### PR TITLE
Fix Strict (2048): Declaration of BootstrapFormHelper::radio() should be...

### DIFF
--- a/Test/Case/View/Helper/BootstrapHelperTest.php
+++ b/Test/Case/View/Helper/BootstrapHelperTest.php
@@ -35,7 +35,7 @@ class TestBootstrapHelper extends BootstrapHelper {
 	/**
 	 * Overwriting method to return a static string.
 	 */
-	public function _flash_content($key) {
+	public function _flash_content($key = 'flash') {
 		return "Flash content";
 	}
 }

--- a/View/Helper/BootstrapFormHelper.php
+++ b/View/Helper/BootstrapFormHelper.php
@@ -344,10 +344,11 @@ class BootstrapFormHelper extends FormHelper {
 	 * markup for twitter bootstrap styles
 	 *
 	 * @param array $options
+	 * @param array $attributes
 	 * @access public
 	 * @return string
 	 */
-	public function radio($field, $options = array()) {
+	public function radio($field, $options = array(), $attributes = array()) {
 		if (is_array($field)) {
 			$options = $field;
 		} else {
@@ -364,7 +365,7 @@ class BootstrapFormHelper extends FormHelper {
 			$input = parent::radio(
 				$options["field"],
 				array($key => $val),
-				array("label" => false, 'hiddenField' => $hiddenField)
+				$attributes + array("label" => false, 'hiddenField' => $hiddenField)
 			);
 			$id = array();
 			preg_match_all("/id=\"[a-zA-Z0-9_-]*\"/", $input, $id);


### PR DESCRIPTION
... compatible with FormHelper::radio($fieldName, $options = Array, $attributes = Array) [APP/Plugin/TwitterBootstrap/View/Helper/BootstrapFormHelper.php, line 5]
